### PR TITLE
Removed double quotes when terminal is set to false.

### DIFF
--- a/src/windows/index.js
+++ b/src/windows/index.js
@@ -120,7 +120,7 @@ const register = async (options, cb) => {
             commandRegistry.set(
                 Registry.DEFAULT_VALUE,
                 Registry.REG_SZ,
-                (terminal ? 'cmd /k ' : '') + `"${command}"`,
+                terminal ? `cmd /k "${command}"` : command,
                 (err) => {
                     if (err) return reject(err);
                     return resolve(true);


### PR DESCRIPTION
# Description:

When "terminal" is set to false on Windows, registry value is wrapped in double quotes and it is not executed.

<!---give the issue number you fixed----->

## Type of change:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

-   [x] Bug fix (non-breaking change which fixes an issue)
