### PR TITLE
Added support for allusers on Windows.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,6 +32,13 @@ declare namespace ProtocolRegistry {
      * This option is recommended if you are using multi-line commands or your command uses any kind of quotes.
      */
     script?: boolean;
+
+    /**
+     * **default false.**
+     * If this is set true, then the script will try to register the protocol for all users on the system.
+     * It is required to run node as administartor (elevated).
+     */
+     allusers?: boolean;
   };
   export function register(params: RegisterOptions): Promise<void>;
   export function register(

--- a/src/validation/common.js
+++ b/src/validation/common.js
@@ -7,5 +7,6 @@ exports.registerSchema = Joi.object({
     command: Joi.string().required(),
     override: Joi.boolean(),
     terminal: Joi.boolean(),
-    script: Joi.boolean()
+    script: Joi.boolean(),
+    allusers: Joi.boolean()
 });


### PR DESCRIPTION
# Description:

The original script is creating only registry items for the current user `HKEY_CLASSES_ROOT` or precisely in `HKEY_CURRENT_USER\SOFTWARE\Classes` .

I have added support for optional registration for all Windows users or `HKEY_LOCAL_MACHINE\SOFTWARE\Classes` which requires elevated instance of node (Run as administartor) or it will throw corresponding error.


<!---give the issue number you fixed----->

## Type of change:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

-   [x] My code follows the style guidelines of this project.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] My changes generate no new warnings.
