### PR TITLE
Fix incorrect interpretation of exit codes from `xdg-mime` on KDE systems

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -6,6 +6,12 @@ const constants = {
         linux: 'linux',
         macos: 'darwin'
     },
+    desktops: {
+        current: process.env.XDG_CURRENT_DESKTOP,
+        KDE: {
+            noProtoExitCode: 4
+        }
+    },
     homedir: join(require('os').homedir(), '.protocol-registry'),
     urlArgument: {
         win32: '%1',

--- a/src/linux/index.js
+++ b/src/linux/index.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const { join } = require('path');
 const shell = require('../utils/shell');
 const { preProcessCommands } = require('../utils/processCommand');
-
+const constants = require('../config/constants');
 const validator = require('../utils/validator');
 const { registerSchema } = require('../validation/common');
 
@@ -22,10 +22,10 @@ const checkifExists = async (protocol) => {
         KDE returns exit code 4 if the protocol is not registered
         see https://cgit.freedesktop.org/xdg/xdg-utils/tree/scripts/xdg-mime.in#n461
     */
-    const isKDE = process.env.XDG_CURRENT_DESKTOP === 'KDE';
-    const kdeNoProtoExitCode = 4;
-
-    if (isKDE && res.code === kdeNoProtoExitCode) {
+    if (
+        constants.desktops.current === 'KDE' &&
+        res.code === constants.desktops.KDE.noProtoExitCode
+    ) {
         return false;
     }
 

--- a/src/linux/index.js
+++ b/src/linux/index.js
@@ -18,13 +18,21 @@ const checkifExists = async (protocol) => {
         { silent: true }
     );
 
-    if (res.code !== 0 || res.stderr) {
+    /* 
+        KDE returns exit code 4 if the protocol is not registered
+        see https://cgit.freedesktop.org/xdg/xdg-utils/tree/scripts/xdg-mime.in#n461
+    */
+    const isKDE = process.env.XDG_CURRENT_DESKTOP === "KDE";
+    const kdeNoProtoExitCode = 4;
+
+    if((res.code === 0 && !res.stderr) || (isKDE && res.code === kdeNoProtoExitCode)) {
+        if (res.stdout && res.stdout.length > 0) {
+            return true;
+        }
+        return false;
+    } else {
         throw new Error(res.stderr);
     }
-    if (res.stdout && res.stdout.length > 0) {
-        return true;
-    }
-    return false;
 };
 
 /**

--- a/src/linux/index.js
+++ b/src/linux/index.js
@@ -22,17 +22,22 @@ const checkifExists = async (protocol) => {
         KDE returns exit code 4 if the protocol is not registered
         see https://cgit.freedesktop.org/xdg/xdg-utils/tree/scripts/xdg-mime.in#n461
     */
-    const isKDE = process.env.XDG_CURRENT_DESKTOP === "KDE";
+    const isKDE = process.env.XDG_CURRENT_DESKTOP === 'KDE';
     const kdeNoProtoExitCode = 4;
 
-    if((res.code === 0 && !res.stderr) || (isKDE && res.code === kdeNoProtoExitCode)) {
-        if (res.stdout && res.stdout.length > 0) {
-            return true;
-        }
+    if (isKDE && res.code === kdeNoProtoExitCode) {
         return false;
-    } else {
+    }
+
+    if (res.code !== 0 || res.stderr) {
         throw new Error(res.stderr);
     }
+
+    if (res.stdout && res.stdout.length > 0) {
+        return true;
+    }
+
+    return false;
 };
 
 /**


### PR DESCRIPTION
# Description:

This pull request fixes the handling of `xdg-mime` exit codes so the package no longer incorrectly interprets exit code 4 as an error on KDE-based systems. The fix updates the code in the `checkifExists` function to check if the system is using KDE, and if so handles exit code 4 appropriately.

Fixes #39 

## Type of change:

-   [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

-   [X] My code follows the style guidelines of this project.
-   [x] I have performed a self-review of my own code.
-   [X] I have commented my code, particularly in hard-to-understand areas.
-   [X] My changes generate no new warnings.
-   [X] New and existing unit tests pass locally with my changes.
